### PR TITLE
feat: golang add 1.25 features

### DIFF
--- a/.github/workflows/daily_check.yml
+++ b/.github/workflows/daily_check.yml
@@ -48,7 +48,7 @@ jobs:
       continue-on-error: true
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Set up JDK
       continue-on-error: true

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/emirpasic/gods v1.18.1
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module leetCode
 
-go 1.23
+go 1.25
 
 require (
 	github.com/emirpasic/gods v1.18.1
@@ -9,7 +9,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emirpasic/gods/v2 v2.0.0-alpha // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/emirpasic/gods/v2 v2.0.0-alpha/go.mod h1:W0y4M2dtBB9U5z3YlghmpuUhiaZT2h6yoeE+C1sCp6A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/golang/test_basic.go
+++ b/golang/test_basic.go
@@ -193,6 +193,7 @@ func checkSolve(ast *assert.Assertions, testcase TestCase, pkg func(inputJsonVal
 
 func TestEach(t *testing.T, problemId string, problemFolder string, pkg func(inputJsonValues string) any) {
 	ast := assert.New(t)
+	t.Attr("problemId", problemId)
 	tests := processTestcase(fmt.Sprintf(TestcaseFolderFmt, problemFolder, problemFolder, problemId))
 	for j, testcase := range tests {
 		t.Run(fmt.Sprintf("%s/Testcase#%d", problemId, j), func(t *testing.T) {

--- a/golang/test_basic.go
+++ b/golang/test_basic.go
@@ -1,11 +1,12 @@
 package golang
 
 import (
-	"encoding/json"
+	"encoding/json/v2"
 	"fmt"
 	"log"
 	"os"
 	"path"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 )
 
 const TestcaseFolderFmt = "%s/%s_%s/testcase"
+const RunTimes = 10000
 
 type TestCase struct {
 	input string
@@ -48,106 +50,105 @@ func processTestcase(problemPath string) (tests []TestCase) {
 }
 
 func compareGeneral(ast *assert.Assertions, want any, resp any) bool {
-	switch resp.(type) {
-	case int:
-		return ast.Equal(int(want.(float64)), resp.(int))
-	case int64:
-		return ast.Equal(int64(want.(float64)), resp.(int64))
-	case float64:
-		return ast.InDelta(want, resp, 1e-5)
-	case byte:
-		return ast.Equalf(want.(string)[0], resp, "Expected: [%s], actual: [%s]", want, string(resp.(byte)))
-	case [][]int:
+	respValue := reflect.ValueOf(resp)
+	if num, ok := reflect.TypeAssert[int](respValue); ok {
+		return ast.Equal(int(want.(float64)), num)
+	}
+	if num, ok := reflect.TypeAssert[int64](respValue); ok {
+		return ast.Equal(int64(want.(float64)), num)
+	}
+	if num, ok := reflect.TypeAssert[float64](respValue); ok {
+		return ast.InDelta(want, num, 1e-5)
+	}
+	if bytes, ok := reflect.TypeAssert[byte](respValue); ok {
+		return ast.Equalf(want.(string)[0], bytes, "Expected: [%s], actual: [%s]", want, string(bytes))
+	}
+	if num2DArray, num2DArrayOk := reflect.TypeAssert[[][]int](respValue); num2DArrayOk {
 		wantArray := want.([]any)
-		respIntArray := resp.([][]int)
-		if !ast.Equalf(len(wantArray), len(respIntArray), "Expected: [%v], actual: [%v]", want, resp) {
+		if !ast.Equalf(len(wantArray), len(num2DArray), "Expected: [%v], actual: [%v]", want, resp) {
 			return false
 		}
-		for i := 0; i < len(respIntArray); i++ {
-			if !ast.Equalf(len(wantArray[i].([]any)), len(respIntArray[i]),
+		for i := 0; i < len(num2DArray); i++ {
+			if !ast.Equalf(len(wantArray[i].([]any)), len(num2DArray[i]),
 				"Expected: [%v], actual: [%v]", want, resp) {
 				return false
 			}
-			for j := 0; j < len(respIntArray[i]); j++ {
-				if !ast.Equalf(int(wantArray[i].([]any)[j].(float64)), respIntArray[i][j],
+			for j := 0; j < len(num2DArray[i]); j++ {
+				if !ast.Equalf(int(wantArray[i].([]any)[j].(float64)), num2DArray[i][j],
 					"Expected: [%v], actual: [%v]", want, resp) {
 					return false
 				}
 			}
 		}
-	case []int:
+	} else if numArray, numArrayOk := reflect.TypeAssert[[]int](respValue); numArrayOk {
 		if _, ok := want.([]any); !ok {
-			return ast.Equal(int(want.(float64)), resp.([]int)[0], "Expected: [%v], actual: [%v]", want, resp)
+			return ast.Equal(int(want.(float64)), numArray[0], "Expected: [%v], actual: [%v]", want, resp)
 		}
 		if want == nil {
 			return ast.Nil(resp, "Expected: [%v], actual: [%v]", want, resp)
 		}
 		wantArray := want.([]any)
-		respIntArray := resp.([]int)
-		if !ast.Equalf(len(wantArray), len(respIntArray), "Expected: [%v], actual: [%v]", want, resp) {
+		if !ast.Equalf(len(wantArray), len(numArray), "Expected: [%v], actual: [%v]", want, resp) {
 			return false
 		}
-		for j := 0; j < len(respIntArray); j++ {
-			if !ast.Equalf(int(wantArray[j].(float64)), respIntArray[j], "Expected: [%v], actual: [%v]", want, resp) {
+		for j := 0; j < len(numArray); j++ {
+			if !ast.Equalf(int(wantArray[j].(float64)), numArray[j], "Expected: [%v], actual: [%v]", want, resp) {
 				return false
 			}
 		}
-	case []string:
+	} else if stringArray, stringArrayOk := reflect.TypeAssert[[]string](respValue); stringArrayOk {
 		if v, ok := want.([]string); ok {
-			ast.Equal(v, resp)
+			ast.Equal(v, stringArray)
 			return false
 		}
-		if !ast.Equalf(len(want.([]any)), len(resp.([]string)),
+		if !ast.Equalf(len(want.([]any)), len(stringArray),
 			"Expected: [%v], actual: [%v]", want, resp) {
 			return false
 		}
-		for i := 0; i < len(resp.([]string)); i++ {
-			if !ast.Equalf(want.([]any)[i], resp.([]string)[i],
+		for i := 0; i < len(stringArray); i++ {
+			if !ast.Equalf(want.([]any)[i], stringArray[i],
 				"Expected: [%v], actual: [%v]", want, resp) {
 				return false
 			}
 		}
-	case [][]string:
+	} else if string2DArray, string2DArrayOk := reflect.TypeAssert[[][]string](respValue); string2DArrayOk {
 		wantArray := want.([]any)
-		respStrArray := resp.([][]string)
-		if !ast.Equalf(len(wantArray), len(respStrArray), "Expected: [%v], actual: [%v]", want, resp) {
+		if !ast.Equalf(len(wantArray), len(string2DArray), "Expected: [%v], actual: [%v]", want, resp) {
 			return false
 		}
 
-		for i := 0; i < len(respStrArray); i++ {
-			if !ast.Equalf(len(wantArray[i].([]any)), len(respStrArray[i]),
+		for i := 0; i < len(string2DArray); i++ {
+			if !ast.Equalf(len(wantArray[i].([]any)), len(string2DArray[i]),
 				"Expected: [%v], actual: [%v]", want, resp) {
 				return false
 			}
-			for j := 0; j < len(respStrArray[i]); j++ {
-				if !ast.Equalf(len(wantArray[i].([]any)[j].(string)), len(respStrArray[i][j]),
+			for j := 0; j < len(string2DArray[i]); j++ {
+				if !ast.Equalf(len(wantArray[i].([]any)[j].(string)), len(string2DArray[i][j]),
 					"Expected: [%v], actual: [%v]", want, resp) {
 					return false
 				}
-				if !ast.Equalf(wantArray[i].([]any)[j], respStrArray[i][j],
+				if !ast.Equalf(wantArray[i].([]any)[j], string2DArray[i][j],
 					"Expected: [%v], actual: [%v]", want, resp) {
 					return false
 				}
 			}
 		}
-	case []bool:
+	} else if boolArray, boolArrayOk := reflect.TypeAssert[[]bool](respValue); boolArrayOk {
 		wantArray := want.([]any)
-		respBoolArray := resp.([]bool)
-		if !ast.Equalf(len(wantArray), len(respBoolArray), "Expected: [%v], actual: [%v]", want, resp) {
+		if !ast.Equalf(len(wantArray), len(boolArray), "Expected: [%v], actual: [%v]", want, resp) {
 			return false
 		}
-		for i := 0; i < len(respBoolArray); i++ {
-			if !ast.Equalf(wantArray[i], respBoolArray[i], "Expected: [%v], actual: [%v]", want, resp) {
+		for i := 0; i < len(boolArray); i++ {
+			if !ast.Equalf(wantArray[i], boolArray[i], "Expected: [%v], actual: [%v]", want, resp) {
 				return false
 			}
 		}
-	case []any:
+	} else if respArray, anyArrayOk := reflect.TypeAssert[[]any](respValue); anyArrayOk {
 		defer func() {
 			if recover() != nil {
 				ast.ElementsMatch(want, resp)
 			}
 		}()
-		respArray := resp.([]any)
 		if _, ok := want.([]any); !ok {
 			return ast.Equal(int(want.(float64)), respArray[0], "Expected: [%v], actual: [%v]", want, resp)
 		}
@@ -168,7 +169,7 @@ func compareGeneral(ast *assert.Assertions, want any, resp any) bool {
 		} else {
 			return false
 		}
-	default:
+	} else {
 		return ast.Equal(want, resp)
 	}
 	return true
@@ -179,7 +180,7 @@ func checkSolve(ast *assert.Assertions, testcase TestCase, pkg func(inputJsonVal
 	if !compareGeneral(ast, testcase.want, gotResp) {
 		secondResp := pkg(testcase.input)
 		if fmt.Sprintf("%v", gotResp) != fmt.Sprintf("%v", secondResp) {
-			for i := 0; i < 10000; i++ {
+			for range RunTimes {
 				if compareGeneral(ast, testcase.want, secondResp) {
 					return true
 				}
@@ -197,8 +198,7 @@ func TestEach(t *testing.T, problemId string, problemFolder string, pkg func(inp
 	tests := processTestcase(fmt.Sprintf(TestcaseFolderFmt, problemFolder, problemFolder, problemId))
 	for j, testcase := range tests {
 		t.Run(fmt.Sprintf("%s/Testcase#%d", problemId, j), func(t *testing.T) {
-			fmt.Printf("Input: %v\n", testcase.input)
-			fmt.Printf("Expected: %v\n", testcase.want)
+			fmt.Printf("Input: %v\nExpected: %v\n", testcase.input, testcase.want)
 			if !checkSolve(ast, testcase, pkg) {
 				t.FailNow()
 			}


### PR DESCRIPTION
This pull request updates the Go version used in the project, upgrades a key dependency, and refactors the test comparison logic in `test_basic.go` to use Go's reflection for more robust and maintainable type handling. It also introduces minor improvements to test reporting and configuration.

**Dependency and environment updates:**

* Updated the Go version to 1.25 in both the `go.mod` file and the GitHub Actions workflow (`.github/workflows/daily_check.yml`). [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-L12) [[2]](diffhunk://#diff-27dd242022d47e0d0a748e82c3447ef866ec180c9954d7c59ff70c33bf6a1fa2L51-R51)
* Upgraded `github.com/stretchr/testify` from v1.10.0 to v1.11.1 in `go.mod`.
* Updated JSON import to use `encoding/json/v2` in `golang/test_basic.go`.

**Test framework and code improvements:**

* Refactored the `compareGeneral` function in `golang/test_basic.go` to use reflection-based type assertions instead of type switches, making it easier to maintain and extend support for new types. [[1]](diffhunk://#diff-065863fa0f8282394b11e123efc6818691de6ef172e5928e29989f28e2dc009bL51-L150) [[2]](diffhunk://#diff-065863fa0f8282394b11e123efc6818691de6ef172e5928e29989f28e2dc009bL171-R172)
* Added a `RunTimes` constant for controlling the number of test retries, and used it in the retry loop for test comparisons. [[1]](diffhunk://#diff-065863fa0f8282394b11e123efc6818691de6ef172e5928e29989f28e2dc009bR18) [[2]](diffhunk://#diff-065863fa0f8282394b11e123efc6818691de6ef172e5928e29989f28e2dc009bL182-R183)
* Improved test reporting by adding `problemId` as a test attribute and consolidating input/expected value printing.