### PR TITLE
feat: 社区题解分页与展示优化

### DIFF
--- a/python/lc_libs/answers.py
+++ b/python/lc_libs/answers.py
@@ -78,7 +78,7 @@ def get_answer_endlesscheng(problem_slug: str, cookie: str) -> Optional[Dict]:
     return get_solution_by_author(problem_slug, "endlesscheng", cookie)
 
 
-def get_answer_articles(problem_slug: str, cookie: str, first: int = 5) -> List[Dict]:
+def get_answer_articles(problem_slug: str, cookie: str, first: int = 5, skip: int = 0) -> Dict:
     """
     获取指定题目的社区热门题解列表
 
@@ -86,12 +86,15 @@ def get_answer_articles(problem_slug: str, cookie: str, first: int = 5) -> List[
         problem_slug: 题目 slug
         cookie: LeetCode Cookie
         first: 返回数量，默认 5
+        skip: 跳过数量，默认 0（用于分页）
 
     Returns:
-        题解列表，每个元素含 slug, title, author, upvoteCount, hitCount, summary 等
+        字典，包含:
+        - total: 总数
+        - articles: 题解列表，每个元素含 slug, title, author, upvoteCount, hitCount, summary 等
     """
     if not cookie:
         logging.warning("Cookie is empty, cannot fetch solution articles")
-        return []
+        return {"total": 0, "articles": []}
     from python.lc_libs.solution_article import get_solution_articles
-    return get_solution_articles(problem_slug, cookie, first=first)
+    return get_solution_articles(problem_slug, cookie, first=first, skip=skip)

--- a/python/lc_libs/solution_article.py
+++ b/python/lc_libs/solution_article.py
@@ -201,7 +201,9 @@ def get_solution_articles(question_slug: str, cookie: str, author_slug: str = No
                 continue
         articles.append(node)
 
-    return {"total": result.get("total", 0), "articles": articles}
+    # 当有 author 过滤时，total 使用过滤后的实际数量
+    actual_total = len(articles) if author_slug else result.get("total", 0)
+    return {"total": actual_total, "articles": articles}
 
 
 def get_solution_by_author(question_slug: str, author_slug: str, cookie: str) -> Optional[Dict]:

--- a/python/lc_libs/solution_article.py
+++ b/python/lc_libs/solution_article.py
@@ -129,7 +129,7 @@ def get_solution_content(solution_slug: str, cookie: str, max_retries: int = 3) 
 
 
 def get_solution_articles(question_slug: str, cookie: str, author_slug: str = None,
-                          first: int = 15, order_by: str = "DEFAULT") -> List[Dict]:
+                          first: int = 15, skip: int = 0, order_by: str = "DEFAULT") -> Dict:
     """
     获取指定题目下的题解列表
 
@@ -138,23 +138,30 @@ def get_solution_articles(question_slug: str, cookie: str, author_slug: str = No
         cookie: LeetCode Cookie
         author_slug: 可选，指定作者的 slug，如 'endlesscheng'（使用 userInput 服务端过滤）
         first: 返回数量，默认 15
+        skip: 跳过数量，默认 0（用于分页）
         order_by: 排序方式，默认 'DEFAULT'，可选 'MOST_POPULAR'
 
     Returns:
-        题解列表，每个元素包含 slug, title, author, upvoteCount, summary 等
+        字典，包含:
+        - total: 总数
+        - articles: 题解列表，每个元素包含 slug, title, author, upvoteCount, summary 等
     """
     if not cookie:
         logging.warning("Cookie is empty, cannot fetch solution articles")
-        return []
+        return {"total": 0, "articles": []}
 
     def handle_response(response):
         data = json.loads(response.text)
         if data.get("errors"):
             logging.warning(f"GraphQL errors in get_solution_articles: {data['errors']}")
-            return []
+            return None
         if data.get("data") and data["data"].get("questionSolutionArticles"):
-            return data["data"]["questionSolutionArticles"]["edges"]
-        return []
+            result_data = data["data"]["questionSolutionArticles"]
+            return {
+                "total": result_data.get("totalNum", 0),
+                "edges": result_data.get("edges", [])
+            }
+        return None
 
     # 当指定 author_slug 时，增大 first 并使用 userInput 服务端过滤
     actual_first = first if not author_slug else min(first * 3, 50)
@@ -167,7 +174,7 @@ def get_solution_articles(question_slug: str, cookie: str, author_slug: str = No
             "query": QUESTION_SOLUTION_ARTICLES_QUERY,
             "variables": {
                 "questionSlug": question_slug,
-                "skip": 0,
+                "skip": skip,
                 "first": actual_first,
                 "orderBy": order_by,
                 "userInput": user_input,
@@ -179,11 +186,11 @@ def get_solution_articles(question_slug: str, cookie: str, author_slug: str = No
     )
 
     if not result:
-        return []
+        return {"total": 0, "articles": []}
 
     # 提取 node 数据
     articles = []
-    for edge in result:
+    for edge in result.get("edges", []):
         node = edge.get("node", {})
         if author_slug:
             # 服务端已通过 userInput 过滤，客户端再做精确匹配
@@ -194,7 +201,7 @@ def get_solution_articles(question_slug: str, cookie: str, author_slug: str = No
                 continue
         articles.append(node)
 
-    return articles
+    return {"total": result.get("total", 0), "articles": articles}
 
 
 def get_solution_by_author(question_slug: str, author_slug: str, cookie: str) -> Optional[Dict]:
@@ -209,7 +216,8 @@ def get_solution_by_author(question_slug: str, author_slug: str, cookie: str) ->
     Returns:
         题解内容字典，包含 title, content, author 等；如果没有找到返回 None
     """
-    articles = get_solution_articles(question_slug, cookie, author_slug=author_slug)
+    result = get_solution_articles(question_slug, cookie, author_slug=author_slug)
+    articles = result.get("articles", [])
     if not articles:
         return None
 

--- a/python/scripts/cli/i18n.py
+++ b/python/scripts/cli/i18n.py
@@ -164,6 +164,7 @@ I18N: Dict[str, Dict[str, str]] = {
         "solution_author_not_found": "未找到该作者的题解",
         "solution_fetching": "正在获取题解...",
         "solution_loading_detail": "正在加载题解详情...",
+        "solution_page": "📖 共 [{total}] 条题解 (第 {page}/{max_page} 页)\n{content}\nb.上一页 | n.下一页 | 编号查看详情 | 回车返回\n",
     },
     "en": {
         # Separator
@@ -318,6 +319,7 @@ I18N: Dict[str, Dict[str, str]] = {
         "solution_author_not_found": "No solution found for this author",
         "solution_fetching": "Fetching solutions...",
         "solution_loading_detail": "Loading solution detail...",
+        "solution_page": "📖 Total [{total}] solutions (page {page}/{max_page})\n{content}\nb.Previous | n.Next | Number to view | Enter to go back\n",
     }
 }
 

--- a/python/scripts/cli/i18n.py
+++ b/python/scripts/cli/i18n.py
@@ -165,6 +165,8 @@ I18N: Dict[str, Dict[str, str]] = {
         "solution_fetching": "正在获取题解...",
         "solution_loading_detail": "正在加载题解详情...",
         "solution_page": "📖 共 [{total}] 条题解 (第 {page}/{max_page} 页)\n{content}\nb.上一页 | n.下一页 | 编号查看详情 | 回车返回\n",
+        "solution_first_page": "已是第一页",
+        "solution_last_page": "已是最后一页",
     },
     "en": {
         # Separator
@@ -320,6 +322,8 @@ I18N: Dict[str, Dict[str, str]] = {
         "solution_fetching": "Fetching solutions...",
         "solution_loading_detail": "Loading solution detail...",
         "solution_page": "📖 Total [{total}] solutions (page {page}/{max_page})\n{content}\nb.Previous | n.Next | Number to view | Enter to go back\n",
+        "solution_first_page": "Already on first page",
+        "solution_last_page": "Already on last page",
     }
 }
 

--- a/python/scripts/leetcode.py
+++ b/python/scripts/leetcode.py
@@ -849,18 +849,6 @@ def _get_problem_slug_from_id(problem_id: str, cookie: str) -> Optional[str]:
     return None
 
 
-def _display_articles(articles: list):
-    """展示题解列表"""
-    for i, article in enumerate(articles, 1):
-        author_info = article.get("author", {})
-        profile = author_info.get("profile", {})
-        author_name = profile.get("realName", "") or author_info.get("username", "?")
-        title = article.get("title", "")
-        upvote = article.get("upvoteCount", 0)
-        display_title = title[:45] + "..." if len(title) > 45 else title
-        print(f"  {i}. {display_title} | {author_name} | 👍{upvote}")
-
-
 def _save_solution(article_content: dict, problem_folder: str, problem_id: str):
     """保存题解到本地文件"""
     problem_dir = root_path / problem_folder / f"{problem_folder}_{back_question_id(problem_id)}"
@@ -884,7 +872,7 @@ def _save_solution(article_content: dict, problem_folder: str, problem_id: str):
 
 
 def _browse_community_solutions(cookie: str, problem_folder: str):
-    """浏览社区题解"""
+    """浏览社区题解（支持分页）"""
     problem_id_input = input_until_valid(t("solution_enter_problem_id"), allow_all_not_empty,
                                           t("solution_problem_id_empty"))
     print(SEPARATE_LINE)
@@ -896,27 +884,63 @@ def _browse_community_solutions(cookie: str, problem_folder: str):
         print(t("solution_no_articles"))
         return
 
-    print(t("solution_fetching"))
-    articles = lc_libs.get_answer_articles(problem_slug, cookie, first=10)
-    if not articles:
-        print(t("solution_no_articles"))
-        return
+    page_size = 10
+    cur_page = 1
 
     while True:
-        print(t("solution_list_header"))
-        _display_articles(articles)
-        print(SEPARATE_LINE)
+        print(t("solution_fetching"))
+        result = lc_libs.get_answer_articles(problem_slug, cookie, first=page_size, skip=(cur_page - 1) * page_size)
+        total = result.get("total", 0)
+        articles = result.get("articles", [])
 
-        select = input_until_valid(t("solution_select_view"), allow_all)
-        if not select.isdigit() or int(select) == 0:
-            return
-        idx = int(select) - 1
-        if idx < 0 or idx >= len(articles):
+        if not articles:
             print(t("solution_no_articles"))
+            return
+
+        max_page = math.ceil(total / page_size)
+        # 构建题解列表展示
+        lines = []
+        for i, article in enumerate(articles, 1):
+            title = article.get("title", "")
+            author_info = article.get("author", {})
+            profile = author_info.get("profile", {})
+            author_name = profile.get("realName", "") or author_info.get("username", "?")
+            upvote = article.get("upvoteCount", 0)
+            uuid = article.get("uuid", "")
+            solution_link = f"https://leetcode.cn/problems/{problem_slug}/solutions/{uuid}/" if uuid else ""
+            lines.append(f"  {i}. {title}")
+            lines.append(f"     👤{author_name} | 👍{upvote}")
+            if solution_link:
+                lines.append(f"     🔗 {solution_link}")
+        content = "\n".join(lines)
+
+        select = input_until_valid(
+            t("solution_page", total=total, page=cur_page, max_page=max_page, content=content),
+            allow_all
+        )
+
+        pick = None
+        match select:
+            case "" | "0":
+                # 回车或 0 返回
+                return
+            case "b":
+                cur_page = max(1, cur_page - 1)
+            case "n":
+                cur_page = min(max_page, cur_page + 1)
+            case v if v.isdigit() and 1 <= int(v) <= len(articles):
+                pick = int(v)
+            case _:
+                # 其他无效输入，继续显示当前页
+                continue
+
+        print(SEPARATE_LINE)
+        if not pick:
             continue
 
-        article = articles[idx]
+        article = articles[pick - 1]
         slug = article.get("slug")
+        uuid = article.get("uuid", "")
         if not slug:
             continue
 
@@ -924,8 +948,49 @@ def _browse_community_solutions(cookie: str, problem_folder: str):
         from python.lc_libs.solution_article import get_solution_content
         detail = get_solution_content(slug, cookie)
         if detail:
+            title = detail.get("title", "")
+            author_info = detail.get("author", {})
+            profile = author_info.get("profile", {})
+            author_name = profile.get("realName", "") or author_info.get("username", "?")
+            upvote = detail.get("upvoteCount", 0)
             content = detail.get("content", "")
-            print(content[:2000] + ("..." if len(content) > 2000 else ""))
+            solution_link = f"https://leetcode.cn/problems/{problem_slug}/solutions/{uuid}/" if uuid else ""
+
+            # 展示题解预览
+            print(f"\n┌{'─' * 48}┐")
+            print(f"│ 📄 {title[:42]}{' ' * (44 - min(len(title), 44))}│")
+            print(f"│ 👤 {author_name[:42]}{' ' * (44 - min(len(author_name), 44))}│")
+            print(f"│ 👍 {upvote:<42}│")
+            if solution_link:
+                print(f"│ 🔗 {solution_link[:42]}{' ' * (44 - min(len(solution_link), 44))}│")
+            print(f"└{'─' * 48}┘")
+
+            # 使用分页器展示内容
+            if content:
+                import subprocess
+                import tempfile
+                try:
+                    # 写入临时文件
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, encoding='utf-8') as f:
+                        f.write(f"# {title}\n\n")
+                        f.write(f"> Author: {author_name} | Upvotes: {upvote}\n\n")
+                        f.write(content)
+                        tmp_path = f.name
+
+                    # 使用 less 或系统默认分页器
+                    pager = os.environ.get('PAGER', 'less -R')
+                    subprocess.run(f"{pager} '{tmp_path}'", shell=True, check=True)
+                    os.unlink(tmp_path)
+                except Exception:
+                    # 如果分页器失败，直接打印前 100 行
+                    print("\n" + SEPARATE_LINE)
+                    lines = content.split('\n')
+                    for line in lines[:100]:
+                        print(line)
+                    if len(lines) > 100:
+                        print(f"\n... (共 {len(lines)} 行，已截断)")
+                    print(SEPARATE_LINE)
+
             save_input = input_until_valid(t("solution_save"), allow_all)
             if save_input.lower() == "y":
                 _save_solution(detail, problem_folder, problem_id_input)
@@ -962,8 +1027,41 @@ def _view_author_solutions(cookie: str, problem_folder: str):
     author_name = profile.get("realName", "") or author_info.get("username", "?")
     title = detail.get("title", "")
     upvote = detail.get("upvoteCount", 0)
-    print(f"  {title} | {author_name} | 👍{upvote}")
-    print(SEPARATE_LINE)
+    uuid = detail.get("uuid", "")
+    content = detail.get("content", "")
+    solution_link = f"https://leetcode.cn/problems/{problem_slug}/solutions/{uuid}/" if uuid else ""
+
+    # 展示题解预览
+    print(f"\n┌{'─' * 48}┐")
+    print(f"│ 📄 {title[:42]}{' ' * (44 - min(len(title), 44))}│")
+    print(f"│ 👤 {author_name[:42]}{' ' * (44 - min(len(author_name), 44))}│")
+    print(f"│ 👍 {upvote:<42}│")
+    if solution_link:
+        print(f"│ 🔗 {solution_link[:42]}{' ' * (44 - min(len(solution_link), 44))}│")
+    print(f"└{'─' * 48}┘")
+
+    # 使用分页器展示内容
+    if content:
+        import subprocess
+        import tempfile
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, encoding='utf-8') as f:
+                f.write(f"# {title}\n\n")
+                f.write(f"> Author: {author_name} | Upvotes: {upvote}\n\n")
+                f.write(content)
+                tmp_path = f.name
+
+            pager = os.environ.get('PAGER', 'less -R')
+            subprocess.run(f"{pager} '{tmp_path}'", shell=True, check=True)
+            os.unlink(tmp_path)
+        except Exception:
+            print("\n" + SEPARATE_LINE)
+            lines = content.split('\n')
+            for line in lines[:100]:
+                print(line)
+            if len(lines) > 100:
+                print(f"\n... (共 {len(lines)} 行，已截断)")
+            print(SEPARATE_LINE)
 
     save_input = input_until_valid(t("solution_save"), allow_all)
     if save_input.lower() == "y":

--- a/python/scripts/leetcode.py
+++ b/python/scripts/leetcode.py
@@ -849,6 +849,86 @@ def _get_problem_slug_from_id(problem_id: str, cookie: str) -> Optional[str]:
     return None
 
 
+def _display_width(s: str) -> int:
+    """计算字符串在终端的显示宽度（中文等宽字符占两列）"""
+    import unicodedata
+    return sum(2 if unicodedata.east_asian_width(c) in ('W', 'F') else 1 for c in s)
+
+
+def _pad_to_width(s: str, width: int) -> str:
+    """将字符串填充到指定显示宽度"""
+    current_width = _display_width(s)
+    if current_width >= width:
+        return s
+    return s + ' ' * (width - current_width)
+
+
+def _display_solution_detail(title: str, author_name: str, upvote: int,
+                              content: str, solution_link: str) -> bool:
+    """
+    展示题解详情（边界框 + 分页器）
+
+    Returns:
+        True 如果用户选择保存，False 否则
+    """
+    # 边界框展示元信息（固定宽度 50）
+    box_width = 50
+    content_width = box_width - 4  # 去掉 "│ " 和 " │"
+
+    print(f"\n┌{'─' * (box_width - 2)}┐")
+
+    # 标题行（截断并填充）
+    title_display = title[:content_width - 2] if _display_width(title) > content_width - 2 else title
+    print(f"│ 📄 {_pad_to_width(title_display, content_width - 2)}│")
+
+    # 作者行
+    author_display = author_name[:content_width - 2] if _display_width(author_name) > content_width - 2 else author_name
+    print(f"│ 👤 {_pad_to_width(author_display, content_width - 2)}│")
+
+    # 点赞行
+    upvote_str = str(upvote)
+    print(f"│ 👍 {_pad_to_width(upvote_str, content_width - 2)}│")
+
+    # 链接行（如果有）
+    if solution_link:
+        link_display = solution_link[:content_width - 2] if len(solution_link) > content_width - 2 else solution_link
+        print(f"│ 🔗 {_pad_to_width(link_display, content_width - 2)}│")
+
+    print(f"└{'─' * (box_width - 2)}┘")
+
+    # 使用分页器展示内容
+    if content:
+        import subprocess
+        import tempfile
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, encoding='utf-8') as f:
+                f.write(f"# {title}\n\n")
+                f.write(f"> Author: {author_name} | Upvotes: {upvote}\n\n")
+                f.write(content)
+                tmp_path = f.name
+
+            # 使用列表形式避免 shell 注入
+            import shlex
+            pager_cmd = shlex.split(os.environ.get('PAGER', 'less -R'))
+            subprocess.run(pager_cmd + [tmp_path])
+        except Exception:
+            # 如果分页器失败，直接打印前 100 行
+            print("\n" + SEPARATE_LINE)
+            lines = content.split('\n')
+            for line in lines[:100]:
+                print(line)
+            if len(lines) > 100:
+                print(f"\n... (共 {len(lines)} 行，已截断)")
+            print(SEPARATE_LINE)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    save_input = input_until_valid(t("solution_save"), allow_all)
+    return save_input.lower() == "y"
+
+
 def _save_solution(article_content: dict, problem_folder: str, problem_id: str):
     """保存题解到本地文件"""
     problem_dir = root_path / problem_folder / f"{problem_folder}_{back_question_id(problem_id)}"
@@ -925,9 +1005,15 @@ def _browse_community_solutions(cookie: str, problem_folder: str):
                 # 回车或 0 返回
                 return
             case "b":
-                cur_page = max(1, cur_page - 1)
+                if cur_page == 1:
+                    print(t("solution_first_page"))
+                else:
+                    cur_page = max(1, cur_page - 1)
             case "n":
-                cur_page = min(max_page, cur_page + 1)
+                if cur_page == max_page:
+                    print(t("solution_last_page"))
+                else:
+                    cur_page = min(max_page, cur_page + 1)
             case v if v.isdigit() and 1 <= int(v) <= len(articles):
                 pick = int(v)
             case _:
@@ -956,43 +1042,7 @@ def _browse_community_solutions(cookie: str, problem_folder: str):
             content = detail.get("content", "")
             solution_link = f"https://leetcode.cn/problems/{problem_slug}/solutions/{uuid}/" if uuid else ""
 
-            # 展示题解预览
-            print(f"\n┌{'─' * 48}┐")
-            print(f"│ 📄 {title[:42]}{' ' * (44 - min(len(title), 44))}│")
-            print(f"│ 👤 {author_name[:42]}{' ' * (44 - min(len(author_name), 44))}│")
-            print(f"│ 👍 {upvote:<42}│")
-            if solution_link:
-                print(f"│ 🔗 {solution_link[:42]}{' ' * (44 - min(len(solution_link), 44))}│")
-            print(f"└{'─' * 48}┘")
-
-            # 使用分页器展示内容
-            if content:
-                import subprocess
-                import tempfile
-                try:
-                    # 写入临时文件
-                    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, encoding='utf-8') as f:
-                        f.write(f"# {title}\n\n")
-                        f.write(f"> Author: {author_name} | Upvotes: {upvote}\n\n")
-                        f.write(content)
-                        tmp_path = f.name
-
-                    # 使用 less 或系统默认分页器
-                    pager = os.environ.get('PAGER', 'less -R')
-                    subprocess.run(f"{pager} '{tmp_path}'", shell=True, check=True)
-                    os.unlink(tmp_path)
-                except Exception:
-                    # 如果分页器失败，直接打印前 100 行
-                    print("\n" + SEPARATE_LINE)
-                    lines = content.split('\n')
-                    for line in lines[:100]:
-                        print(line)
-                    if len(lines) > 100:
-                        print(f"\n... (共 {len(lines)} 行，已截断)")
-                    print(SEPARATE_LINE)
-
-            save_input = input_until_valid(t("solution_save"), allow_all)
-            if save_input.lower() == "y":
+            if _display_solution_detail(title, author_name, upvote, content, solution_link):
                 _save_solution(detail, problem_folder, problem_id_input)
         else:
             print(t("solution_no_articles"))
@@ -1031,40 +1081,7 @@ def _view_author_solutions(cookie: str, problem_folder: str):
     content = detail.get("content", "")
     solution_link = f"https://leetcode.cn/problems/{problem_slug}/solutions/{uuid}/" if uuid else ""
 
-    # 展示题解预览
-    print(f"\n┌{'─' * 48}┐")
-    print(f"│ 📄 {title[:42]}{' ' * (44 - min(len(title), 44))}│")
-    print(f"│ 👤 {author_name[:42]}{' ' * (44 - min(len(author_name), 44))}│")
-    print(f"│ 👍 {upvote:<42}│")
-    if solution_link:
-        print(f"│ 🔗 {solution_link[:42]}{' ' * (44 - min(len(solution_link), 44))}│")
-    print(f"└{'─' * 48}┘")
-
-    # 使用分页器展示内容
-    if content:
-        import subprocess
-        import tempfile
-        try:
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False, encoding='utf-8') as f:
-                f.write(f"# {title}\n\n")
-                f.write(f"> Author: {author_name} | Upvotes: {upvote}\n\n")
-                f.write(content)
-                tmp_path = f.name
-
-            pager = os.environ.get('PAGER', 'less -R')
-            subprocess.run(f"{pager} '{tmp_path}'", shell=True, check=True)
-            os.unlink(tmp_path)
-        except Exception:
-            print("\n" + SEPARATE_LINE)
-            lines = content.split('\n')
-            for line in lines[:100]:
-                print(line)
-            if len(lines) > 100:
-                print(f"\n... (共 {len(lines)} 行，已截断)")
-            print(SEPARATE_LINE)
-
-    save_input = input_until_valid(t("solution_save"), allow_all)
-    if save_input.lower() == "y":
+    if _display_solution_detail(title, author_name, upvote, content, solution_link):
         _save_solution(detail, problem_folder, problem_id_input)
     print(SEPARATE_LINE)
 


### PR DESCRIPTION
## Summary
- 社区题解浏览支持分页（`b` 上一页、`n` 下一页，回车返回）
- 题解详情使用边界框展示元信息（标题/作者/点赞/链接），与前后输出明显区分
- 题解内容写入临时 .md 文件，使用系统分页器（less）展示完整 Markdown
- 操作提示移至列表底部，回车默认返回

## Test plan
- [ ] 进入题解中心 → 浏览社区题解，输入题目 ID
- [ ] 验证分页：`n` 下一页、`b` 上一页正常切换
- [ ] 验证回车默认返回题解中心
- [ ] 验证题解详情边界框、链接可点击
- [ ] 验证 `--en` 英文模式展示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)